### PR TITLE
Make MKNumberBadgeView "invisible" to touches

### DIFF
--- a/MKNumberBadgeView.m
+++ b/MKNumberBadgeView.m
@@ -83,7 +83,8 @@
 	self.fillColor = [UIColor redColor];
 	self.strokeColor = [UIColor whiteColor];
 	self.textColor = [UIColor whiteColor];
-    self.hideWhenZero = NO;
+	self.hideWhenZero = NO;
+	self.userInteractionEnabled = NO; // so the badge view doesn't intercept touches when placed above a button
 	
 	self.backgroundColor = [UIColor clearColor];
 }


### PR DESCRIPTION
We use the badge above a button and it was intercepting some touch events. Maybe others need this too.
