### PR TITLE
Swapped UITextAlignment for NSTextAlignment & added "text" property

### DIFF
--- a/MKNumberBadgeView.h
+++ b/MKNumberBadgeView.h
@@ -64,7 +64,7 @@
 @property (retain,nonatomic) UIColor* textColor;
 
 // How the badge image hould be aligned horizontally in the view. 
-@property (assign,nonatomic) UITextAlignment alignment;
+@property (assign,nonatomic) NSTextAlignment alignment;
 
 // Returns the visual size of the badge for the current value. Not the same hing as the size of the view's bounds.
 // The badge view bounds should be wider than space needed to draw the badge.

--- a/MKNumberBadgeView.h
+++ b/MKNumberBadgeView.h
@@ -40,6 +40,7 @@
 
 // The current value displayed in the badge. Updating the value will update the view's display
 @property (assign,nonatomic) NSUInteger value;
+@property (strong,nonatomic) NSString *text;
 
 // Indicates whether the badge view draws a dhadow or not.
 @property (assign,nonatomic) BOOL shadow;

--- a/MKNumberBadgeView.m
+++ b/MKNumberBadgeView.m
@@ -79,7 +79,7 @@
 	self.shadow = YES;
 	self.shadowOffset = CGSizeMake(0, 3);
 	self.shine = YES;
-	self.alignment = UITextAlignmentCenter;
+	self.alignment = NSTextAlignmentCenter;
 	self.fillColor = [UIColor redColor];
 	self.strokeColor = [UIColor whiteColor];
 	self.textColor = [UIColor whiteColor];
@@ -128,13 +128,13 @@
 	switch (self.alignment) 
 	{
 		default:
-		case UITextAlignmentCenter:
+		case NSTextAlignmentCenter:
 			ctm = CGPointMake( round((viewBounds.size.width - badgeRect.size.width)/2), round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
-		case UITextAlignmentLeft:
+		case NSTextAlignmentLeft:
 			ctm = CGPointMake( 0, round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
-		case UITextAlignmentRight:
+		case NSTextAlignmentRight:
 			ctm = CGPointMake( (viewBounds.size.width - badgeRect.size.width), round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
 	}

--- a/MKNumberBadgeView.m
+++ b/MKNumberBadgeView.m
@@ -97,7 +97,10 @@
 	
 	CGContextRef curContext = UIGraphicsGetCurrentContext();
 
-	NSString* numberString = [NSString stringWithFormat:@"%d",self.value];
+    NSString* numberString = nil;
+    
+    if (_text) numberString = self.text;
+    else numberString = [NSString stringWithFormat:@"%d",self.value];
 	
 	
 	CGSize numberSize = [numberString sizeWithFont:self.font];
@@ -254,6 +257,7 @@
 - (void)setValue:(NSUInteger)inValue
 {
 	_value = inValue;
+    _text = nil;
     
     if (self.hideWhenZero == YES && _value == 0)
     {
@@ -267,9 +271,29 @@
 	[self setNeedsDisplay];
 }
 
+- (void)setText:(NSString*)inText
+{
+	_text = inText;
+    _value = 0;
+    
+    if (self.hideWhenZero == YES && _text == nil)
+    {
+        self.hidden = YES;
+    }
+    else
+    {
+        self.hidden = NO;
+    }
+	
+	[self setNeedsDisplay];
+}
+
 - (CGSize)badgeSize
 {
-	NSString* numberString = [NSString stringWithFormat:@"%d",self.value];
+	NSString* numberString = nil;
+    
+    if (_text) numberString = self.text;
+    else numberString = [NSString stringWithFormat:@"%d",self.value];
 	
 	
 	CGSize numberSize = [numberString sizeWithFont:self.font];

--- a/MKNumberBadgeView.podspec
+++ b/MKNumberBadgeView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'MKNumberBadgeView'
-  s.version      = '0.0.1'
+  s.version      = '0.0.2'
   s.license      = {
                     :type => 'Apache License, Version 2.0',
                     :text => '


### PR DESCRIPTION
First change is to get rid of the warnings since iOS6 deprecated UITextAlignment.
Second change is to give the developer more flexibility - can still set "value" as previously, but can also now set "text". Setting one will override the other, therefore the dev can change between them easily.

Bumped the podspec to 0.0.2 and have tagged the repo appropriately (I think!)
